### PR TITLE
output service_account_email_address

### DIFF
--- a/modules/cloud-sql/outputs.tf
+++ b/modules/cloud-sql/outputs.tf
@@ -185,3 +185,8 @@ output "complete" {
   description = "Output signaling that all resources have been created"
   value       = data.template_file.complete.rendered
 }
+
+output "service_account_email_address" {
+  description = "Service account email address associated with the CloudSQL instance"
+  value       = google_sql_database_instance.master.service_account_email_address
+}


### PR DESCRIPTION
I need to give the cloud sql service account access to a GCS bucket, like this:
```
resource "google_storage_bucket_iam_binding" "bucket" {
 role   = "roles/storage.objectCreator"
 bucket = google_storage_bucket.bucket.name

 members = [
  "serviceAccount:${module.mydatabase.service_account_email_address}"
 ]
}
```

I did not add tests, as not all outputs appear to be tested. I can add test cases if required. The existing test suite passes. 

Currently I am using my fork with success.