### PR TITLE
Support instance deletion protection

### DIFF
--- a/examples/client-certificate/main.tf
+++ b/examples/client-certificate/main.tf
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 provider "google-beta" {
-  version = "~> 3.43.0"
+  version = "~> 3.57.0"
   project = var.project
   region  = var.region
 }

--- a/examples/mysql-private-ip/main.tf
+++ b/examples/mysql-private-ip/main.tf
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 provider "google-beta" {
-  version = "~> 3.43.0"
+  version = "~> 3.57.0"
   project = var.project
   region  = var.region
 }

--- a/examples/mysql-private-ip/main.tf
+++ b/examples/mysql-private-ip/main.tf
@@ -80,6 +80,11 @@ module "mysql" {
   engine       = var.mysql_version
   machine_type = var.machine_type
 
+  # To make it easier to test this example, we are disabling deletion protection so we can destroy the databases
+  # during the tests. By default, we recommend setting deletion_protection to true, to ensure database instances are
+  # not inadvertently destroyed.
+  deletion_protection = false
+
   # These together will construct the master_user privileges, i.e.
   # 'master_user_name'@'master_user_host' IDENTIFIED BY 'master_user_password'.
   # These should typically be set as the environment variable TF_VAR_master_user_password, etc.

--- a/examples/mysql-public-ip/main.tf
+++ b/examples/mysql-public-ip/main.tf
@@ -59,10 +59,13 @@ module "mysql" {
   master_user_name = var.master_user_name
   master_user_host = "%"
 
-  # To make it easier to test this example, we are giving the servers public IP addresses and allowing inbound
-  # connections from anywhere. In real-world usage, your servers should live in private subnets, only have private IP
-  # addresses, and only allow access from specific trusted networks, servers or applications in your VPC.
+  # To make it easier to test this example, we are giving the instances public IP addresses and allowing inbound
+  # connections from anywhere. We also disable deletion protection so we can destroy the databases during the tests.
+  # In real-world usage, your instances should live in private subnets, only have private IP addresses, and only allow
+  # access from specific trusted networks, servers or applications in your VPC. By default, we recommend setting
+  # deletion_protection to true, to ensure database instances are not inadvertently destroyed.
   enable_public_internet_access = true
+  deletion_protection = false
 
   # Default setting for this is 'false' in 'variables.tf'
   # In the test cases, we're setting this to true, to test forced SSL.

--- a/examples/mysql-public-ip/main.tf
+++ b/examples/mysql-public-ip/main.tf
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 provider "google-beta" {
-  version = "~> 3.43.0"
+  version = "~> 3.57.0"
   project = var.project
   region  = var.region
 }

--- a/examples/mysql-public-ip/main.tf
+++ b/examples/mysql-public-ip/main.tf
@@ -65,7 +65,7 @@ module "mysql" {
   # access from specific trusted networks, servers or applications in your VPC. By default, we recommend setting
   # deletion_protection to true, to ensure database instances are not inadvertently destroyed.
   enable_public_internet_access = true
-  deletion_protection = false
+  deletion_protection           = false
 
   # Default setting for this is 'false' in 'variables.tf'
   # In the test cases, we're setting this to true, to test forced SSL.

--- a/examples/mysql-replicas/main.tf
+++ b/examples/mysql-replicas/main.tf
@@ -54,10 +54,13 @@ module "mysql" {
 
   master_zone = var.master_zone
 
-  # To make it easier to test this example, we are giving the servers public IP addresses and allowing inbound
-  # connections from anywhere. In real-world usage, your servers should live in private subnets, only have private IP
-  # addresses, and only allow access from specific trusted networks, servers or applications in your VPC.
+  # To make it easier to test this example, we are giving the instances public IP addresses and allowing inbound
+  # connections from anywhere. We also disable deletion protection so we can destroy the databases during the tests.
+  # In real-world usage, your instances should live in private subnets, only have private IP addresses, and only allow
+  # access from specific trusted networks, servers or applications in your VPC. By default, we recommend setting
+  # deletion_protection to true, to ensure database instances are not inadvertently destroyed.
   enable_public_internet_access = true
+  deletion_protection = false
 
   authorized_networks = [
     {

--- a/examples/mysql-replicas/main.tf
+++ b/examples/mysql-replicas/main.tf
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 provider "google-beta" {
-  version = "~> 3.43.0"
+  version = "~> 3.57.0"
   project = var.project
   region  = var.region
 }

--- a/examples/mysql-replicas/main.tf
+++ b/examples/mysql-replicas/main.tf
@@ -60,7 +60,7 @@ module "mysql" {
   # access from specific trusted networks, servers or applications in your VPC. By default, we recommend setting
   # deletion_protection to true, to ensure database instances are not inadvertently destroyed.
   enable_public_internet_access = true
-  deletion_protection = false
+  deletion_protection           = false
 
   authorized_networks = [
     {

--- a/examples/postgres-private-ip/main.tf
+++ b/examples/postgres-private-ip/main.tf
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 provider "google-beta" {
-  version = "~> 3.43.0"
+  version = "~> 3.57.0"
   project = var.project
   region  = var.region
 }

--- a/examples/postgres-private-ip/main.tf
+++ b/examples/postgres-private-ip/main.tf
@@ -80,6 +80,11 @@ module "postgres" {
   engine       = var.postgres_version
   machine_type = var.machine_type
 
+  # To make it easier to test this example, we are disabling deletion protection so we can destroy the databases
+  # during the tests. By default, we recommend setting deletion_protection to true, to ensure database instances are
+  # not inadvertently destroyed.
+  deletion_protection = false
+
   # These together will construct the master_user privileges, i.e.
   # 'master_user_name'@'master_user_host' IDENTIFIED BY 'master_user_password'.
   # These should typically be set as the environment variable TF_VAR_master_user_password, etc.

--- a/examples/postgres-public-ip/main.tf
+++ b/examples/postgres-public-ip/main.tf
@@ -57,10 +57,13 @@ module "postgres" {
   master_user_password = var.master_user_password
   master_user_name     = var.master_user_name
 
-  # To make it easier to test this example, we are giving the servers public IP addresses and allowing inbound
-  # connections from anywhere. In real-world usage, your servers should live in private subnets, only have private IP
-  # addresses, and only allow access from specific trusted networks, servers or applications in your VPC.
+  # To make it easier to test this example, we are giving the instances public IP addresses and allowing inbound
+  # connections from anywhere. We also disable deletion protection so we can destroy the databases during the tests.
+  # In real-world usage, your instances should live in private subnets, only have private IP addresses, and only allow
+  # access from specific trusted networks, servers or applications in your VPC. By default, we recommend setting
+  # deletion_protection to true, to ensure database instances are not inadvertently destroyed.
   enable_public_internet_access = true
+  deletion_protection = false
 
   # Default setting for this is 'false' in 'variables.tf'
   # In the test cases, we're setting this to true, to test forced SSL.

--- a/examples/postgres-public-ip/main.tf
+++ b/examples/postgres-public-ip/main.tf
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 provider "google-beta" {
-  version = "~> 3.43.0"
+  version = "~> 3.57.0"
   project = var.project
   region  = var.region
 }

--- a/examples/postgres-public-ip/main.tf
+++ b/examples/postgres-public-ip/main.tf
@@ -63,7 +63,7 @@ module "postgres" {
   # access from specific trusted networks, servers or applications in your VPC. By default, we recommend setting
   # deletion_protection to true, to ensure database instances are not inadvertently destroyed.
   enable_public_internet_access = true
-  deletion_protection = false
+  deletion_protection           = false
 
   # Default setting for this is 'false' in 'variables.tf'
   # In the test cases, we're setting this to true, to test forced SSL.

--- a/examples/postgres-replicas/main.tf
+++ b/examples/postgres-replicas/main.tf
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 provider "google-beta" {
-  version = "~> 3.43.0"
+  version = "~> 3.57.0"
   project = var.project
   region  = var.region
 }

--- a/examples/postgres-replicas/main.tf
+++ b/examples/postgres-replicas/main.tf
@@ -60,7 +60,7 @@ module "postgres" {
   # access from specific trusted networks, servers or applications in your VPC. By default, we recommend setting
   # deletion_protection to true, to ensure database instances are not inadvertently destroyed.
   enable_public_internet_access = true
-  deletion_protection = false
+  deletion_protection           = false
 
   authorized_networks = [
     {

--- a/examples/postgres-replicas/main.tf
+++ b/examples/postgres-replicas/main.tf
@@ -54,10 +54,13 @@ module "postgres" {
 
   master_zone = var.master_zone
 
-  # To make it easier to test this example, we are giving the servers public IP addresses and allowing inbound
-  # connections from anywhere. In real-world usage, your servers should live in private subnets, only have private IP
-  # addresses, and only allow access from specific trusted networks, servers or applications in your VPC.
+  # To make it easier to test this example, we are giving the instances public IP addresses and allowing inbound
+  # connections from anywhere. We also disable deletion protection so we can destroy the databases during the tests.
+  # In real-world usage, your instances should live in private subnets, only have private IP addresses, and only allow
+  # access from specific trusted networks, servers or applications in your VPC. By default, we recommend setting
+  # deletion_protection to true, to ensure database instances are not inadvertently destroyed.
   enable_public_internet_access = true
+  deletion_protection = false
 
   authorized_networks = [
     {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------
 
 provider "google-beta" {
-  version = "~> 3.43.0"
+  version = "~> 3.57.0"
   project = var.project
   region  = var.region
 }

--- a/modules/cloud-sql/main.tf
+++ b/modules/cloud-sql/main.tf
@@ -45,6 +45,9 @@ resource "google_sql_database_instance" "master" {
   region           = var.region
   database_version = var.engine
 
+  # Whether or not to allow Terraform to destroy the instance.
+  deletion_protection = var.deletion_protection
+
   settings {
     tier              = var.machine_type
     activation_policy = var.activation_policy
@@ -173,6 +176,9 @@ resource "google_sql_database_instance" "failover_replica" {
   # The name of the instance that will act as the master in the replication setup.
   master_instance_name = google_sql_database_instance.master.name
 
+  # Whether or not to allow Terraform to destroy the instance.
+  deletion_protection = var.deletion_protection
+
   replica_configuration {
     # Specifies that the replica is the failover target.
     failover_target = true
@@ -252,6 +258,9 @@ resource "google_sql_database_instance" "read_replica" {
 
   # The name of the instance that will act as the master in the replication setup.
   master_instance_name = google_sql_database_instance.master.name
+
+  # Whether or not to allow Terraform to destroy the instance.
+  deletion_protection = var.deletion_protection
 
   replica_configuration {
     # Specifies that the replica is not the failover target.

--- a/modules/cloud-sql/variables.tf
+++ b/modules/cloud-sql/variables.tf
@@ -232,6 +232,13 @@ variable "resource_timeout" {
   default     = "60m"
 }
 
+# Whether or not to allow Terraform to destroy the instance.
+variable "deletion_protection" {
+  description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply command that deletes the instance will fail."
+  type        = bool
+  default     = "true"
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # MODULE DEPENDENCIES
 # Workaround Terraform limitation where there is no module depends_on.


### PR DESCRIPTION
This PR adds support for `deletion_protection` to the `cloud-sql` module and fixes #53. It also bumps the google provider version to 3.57.0. 