### PR TITLE
Update f1-micro to e2-micro instance

### DIFF
--- a/examples/mysql-private-ip/variables.tf
+++ b/examples/mysql-private-ip/variables.tf
@@ -43,7 +43,7 @@ variable "mysql_version" {
 variable "machine_type" {
   description = "The machine type to use, see https://cloud.google.com/sql/pricing for more details"
   type        = string
-  default     = "db-f1-micro"
+  default     = "db-e2-micro"
 }
 
 variable "db_name" {

--- a/examples/mysql-public-ip/variables.tf
+++ b/examples/mysql-public-ip/variables.tf
@@ -43,7 +43,7 @@ variable "mysql_version" {
 variable "machine_type" {
   description = "The machine type to use, see https://cloud.google.com/sql/pricing for more details"
   type        = string
-  default     = "db-f1-micro"
+  default     = "db-e2-micro"
 }
 
 variable "db_name" {

--- a/examples/mysql-replicas/variables.tf
+++ b/examples/mysql-replicas/variables.tf
@@ -66,7 +66,7 @@ variable "mysql_version" {
 variable "machine_type" {
   description = "The machine type to use, see https://cloud.google.com/sql/pricing for more details"
   type        = string
-  default     = "db-f1-micro"
+  default     = "db-e2-micro"
 }
 
 variable "db_name" {

--- a/examples/postgres-private-ip/variables.tf
+++ b/examples/postgres-private-ip/variables.tf
@@ -43,7 +43,7 @@ variable "postgres_version" {
 variable "machine_type" {
   description = "The machine type to use, see https://cloud.google.com/sql/pricing for more details"
   type        = string
-  default     = "db-f1-micro"
+  default     = "db-e2-micro"
 }
 
 variable "db_name" {

--- a/examples/postgres-public-ip/variables.tf
+++ b/examples/postgres-public-ip/variables.tf
@@ -43,7 +43,7 @@ variable "postgres_version" {
 variable "machine_type" {
   description = "The machine type to use, see https://cloud.google.com/sql/pricing for more details"
   type        = string
-  default     = "db-f1-micro"
+  default     = "db-e2-micro"
 }
 
 variable "db_name" {

--- a/examples/postgres-replicas/variables.tf
+++ b/examples/postgres-replicas/variables.tf
@@ -66,7 +66,7 @@ variable "postgres_version" {
 variable "machine_type" {
   description = "The machine type to use, see https://cloud.google.com/sql/pricing for more details"
   type        = string
-  default     = "db-f1-micro"
+  default     = "db-e2-micro"
 }
 
 variable "db_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "postgres_version" {
 
 variable "machine_type" {
   description = "The machine type to use, see https://cloud.google.com/sql/pricing for more details"
-  default     = "db-f1-micro"
+  default     = "db-e2-micro"
 }
 
 variable "db_name" {


### PR DESCRIPTION
I just got an email from GCP stating that the f1-micro is being retired from free tier access and needs to be updated to e2-micro. This PR makes that change.