### PR TITLE
Add `encryption_key_name` to `google_sql_database_instance`. Closes #71

### DIFF
--- a/modules/cloud-sql/main.tf
+++ b/modules/cloud-sql/main.tf
@@ -48,6 +48,8 @@ resource "google_sql_database_instance" "master" {
   # Whether or not to allow Terraform to destroy the instance.
   deletion_protection = var.deletion_protection
 
+  encryption_key_name = var.encryption_key_name
+
   settings {
     tier              = var.machine_type
     activation_policy = var.activation_policy

--- a/modules/cloud-sql/variables.tf
+++ b/modules/cloud-sql/variables.tf
@@ -239,6 +239,16 @@ variable "deletion_protection" {
   default     = "true"
 }
 
+# In order to use this feature, a special kind of service account must be created and granted permission on this key. 
+# This step can currently only be done manually, please see <https://cloud.google.com/sql/docs/mysql/configure-cmek#service-account>. 
+# That service account needs the `Cloud KMS > Cloud KMS CryptoKey Encrypter/Decrypter` role on your key - please see <https://cloud.google.com/sql/docs/mysql/configure-cmek#grantkey>.
+#   https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#encryption_key_name
+variable "encryption_key_name" {
+  description = "The full path to the encryption key used for the CMEK disk encryption. Setting up disk encryption currently requires manual steps outside of Terraform. The provided key must be in the same region as the SQL instance."
+  type        = string
+  default     = null
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # MODULE DEPENDENCIES
 # Workaround Terraform limitation where there is no module depends_on.


### PR DESCRIPTION
Closes ~#78~ Closes https://github.com/gruntwork-io/terraform-google-sql/issues/71

- Adds `encryption_key_name` to `google_sql_database_instance` as per [provider documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#encryption_key_name)
- Defaults to `null` so should cover backwards compatibility