### PR TITLE
crash_safe_replication argument not supported

### DIFF
--- a/modules/cloud-sql/main.tf
+++ b/modules/cloud-sql/main.tf
@@ -185,7 +185,6 @@ resource "google_sql_database_instance" "failover_replica" {
   }
 
   settings {
-    crash_safe_replication = true
 
     tier            = var.machine_type
     disk_autoresize = var.disk_autoresize


### PR DESCRIPTION
When I use this module I get:
```╷
│ Error: Unsupported argument
│ 
│   on main.tf line 188, in resource "google_sql_database_instance" "failover_replica":
│  188:     crash_safe_replication = true
│ 
│ An argument named "crash_safe_replication" is not expected here.
╵
ERRO[0023] 1 error occurred:
        * exit status 1
```
This PR tends to remove it from Terraform manifest as I can not see it in the resource documentation of terraform